### PR TITLE
qfix: floating interdomain tests are unstable on kind cluster

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -44,6 +44,7 @@ func Test_NodeHasChanged(t *testing.T) {
 
 	var conf = &mainpkg.Config{
 		OutputPath: filepath.Join(t.TempDir(), "output.yaml"),
+		NodeName:   "node-1",
 	}
 
 	var client = fake.NewSimpleClientset()


### PR DESCRIPTION
## Motivation

Fixes https://github.com/networkservicemesh/integration-k8s-kind/actions/runs/4230258596/jobs/7347394902

Closes: https://github.com/networkservicemesh/cmd-map-ip-k8s/pull/139
